### PR TITLE
pccsadmin: remove leftover debugging 'print(args)' statement

### DIFF
--- a/PccsAdminTool/pccsadmin.py
+++ b/PccsAdminTool/pccsadmin.py
@@ -56,7 +56,6 @@ def main():
         parser.print_help()
         parser.exit()
 
-    print(args)
     # Check mandatory arguments for appraisalpolicy
     if args.command == 'put' and args.url and args.url.endswith("/appraisalpolicy"):
         if not args.fmspc or not args.input_file:


### PR DESCRIPTION
Dumping the python "Namespace" object to stdout after parsing argv serves no end-user purpose:

```
  $ pccsadmin.py refresh
  Namespace(command='refresh', url=None, fmspc=None, func=<function pccs_refresh at 0x7f9ff61f8510>)
  Please note: A prompt may appear asking for your keyring password to access stored credentials.
  Please input your administrator password for PCCS service:
```

Remove what is presumably a leftover debugging statement:

```
  $ pccsadmin.py refresh
  Please note: A prompt may appear asking for your keyring password to access stored credentials.
  Please input your administrator password for PCCS service:
```