### PR TITLE
Improvements to keyring handling

### DIFF
--- a/PccsAdminTool/lib/intelsgx/credential.py
+++ b/PccsAdminTool/lib/intelsgx/credential.py
@@ -27,7 +27,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import keyring
+try:
+    import keyring
+except:
+    keyring = None
 import getpass
 
 class Credentials:
@@ -36,11 +39,12 @@ class Credentials:
 
     def get_admin_token(self):
         admin_token = ""
-        try:
-            print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
-            admin_token = keyring.get_password(self.APPNAME, self.KEY_ADMINTOKEN)
-        except keyring.errors.KeyringError as ke:
-            admin_token = ""
+        if keyring is not None:
+            try:
+                print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
+                admin_token = keyring.get_password(self.APPNAME, self.KEY_ADMINTOKEN)
+            except keyring.errors.KeyringError as ke:
+                admin_token = ""
         
         while admin_token is None or admin_token == '':
             admin_token = getpass.getpass(prompt="Please input your administrator password for PCCS service:")
@@ -53,10 +57,11 @@ class Credentials:
         return admin_token
 
     def set_admin_token(self, token):
-        try:
-            print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
-            keyring.set_password(self.APPNAME, self.KEY_ADMINTOKEN, token)
-        except keyring.errors.PasswordSetError as ke:
-            print("Failed to store admin token.")
-            return False
+        if keyring is not None:
+            try:
+                print("Please note: A prompt may appear asking for your keyring password to access stored credentials.")
+                keyring.set_password(self.APPNAME, self.KEY_ADMINTOKEN, token)
+            except keyring.errors.PasswordSetError as ke:
+                print("Failed to store admin token.")
+                return False
         return True

--- a/PccsAdminTool/pccsadmin.py
+++ b/PccsAdminTool/pccsadmin.py
@@ -148,7 +148,13 @@ class PccsClient:
             if response.status_code == 200:
                 self._write_output_file(output_file, response)
             elif response.status_code == 401:  # Authentication error
-                self.credentials.set_admin_token('')
+                try:
+                    self.credentials.set_admin_token('')
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
                 print("Authentication failed.")
             else:
                 self._handle_error(response)
@@ -178,7 +184,13 @@ class PccsClient:
                 if response.status_code == 200:
                     print("Collaterals uploaded successfully.")
                 elif response.status_code == 401:  # Authentication error
-                    self.credentials.set_admin_token('')
+                    try:
+                        self.credentials.set_admin_token('')
+                    except:
+                        # If keyring is unavailable, we don't want to trigger
+                        # traceback, as the user may have declined to save
+                        # the key in the keyring earlier
+                        pass
                     print("Authentication failed.")
                 else:
                     self._handle_error(response)
@@ -194,7 +206,13 @@ class PccsClient:
                 if response.status_code == 200:
                     print("Policy uploaded successfully with policy ID :" + response.text)
                 elif response.status_code == 401:  # Authentication error
-                    self.credentials.set_admin_token('')
+                    try:
+                        self.credentials.set_admin_token('')
+                    except:
+                        # If keyring is unavailable, we don't want to trigger
+                        # traceback, as the user may have declined to save
+                        # the key in the keyring earlier
+                        pass
                     print("Authentication failed.")
                 else:
                     self._handle_error(response)
@@ -227,7 +245,13 @@ class PccsClient:
             if response.status_code == 200:
                 print("The cache database was refreshed successfully.")
             elif response.status_code == 401:  # Authentication error
-                self.credentials.set_admin_token('')
+                try:
+                    self.credentials.set_admin_token('')
+                except:
+                    # If keyring is unavailable, we don't want to trigger
+                    # traceback, as the user may have declined to save
+                    # the key in the keyring earlier
+                    pass
                 print("Authentication failed.")
             else:
                 self._handle_error(response)


### PR DESCRIPTION
Not all distros (in my case RHEL-9/10) have the python3-keyring module available.

Use of the keyring is not a critical feature of pccsadmin, just a "nice to have". The user already has the option to decline to store a password in the keyring, so it is conceptually reasonable to support running without the keyring module present at all. 

Furthermore, when seeing an authentication failure, a failure to clear the keyring  should be treated as non-fatal since the user may have declined to store in the keyring to begin with.

Equivalent changes for pcsclient are in https://github.com/intel/confidential-computing.tee.dcap/pull/494
