### PR TITLE
Remove v3 PCS URL downgrade and fix TCB issuer chain header lookup

### DIFF
--- a/service/pcs_client/pcs_client.js
+++ b/service/pcs_client/pcs_client.js
@@ -231,11 +231,6 @@ export async function getTcb(type, fmspc, version, updateType) {
         uri = getTdxUrl(uri);
     }
 
-    if (global.PCS_VERSION === 4 && version === 3) {
-        // A little tricky here because we need to use the v3 PCS URL though v4 is configured
-        uri = uri.replace('/v4/', '/v3/');
-    }
-
     return doRequest(uri, options);
 }
 
@@ -264,11 +259,6 @@ export async function getEnclaveIdentity(enclaveId, version, updateType) {
         uri = `${Config.get('uri')}qve/identity`;
     } else if (enclaveId === Constants.TDQE_IDENTITY_ID) {
         uri = getTdxUrl(uri);
-    }
-
-    if (global.PCS_VERSION === 4 && version === 3) {
-        // A little tricky here because we need to use the v3 PCS URL though v4 is configured
-        uri = uri.replace('/v4/', '/v3/');
     }
 
     return doRequest(uri, options);

--- a/service/services/logic/commonCacheLogic.js
+++ b/service/services/logic/commonCacheLogic.js
@@ -314,9 +314,10 @@ export async function getTcbInfoFromPCS(type, fmspc, version, update_type) {
         tcbinfo: pck_server_res.rawBody
     };
     const issuerChainName = appUtil.getTcbInfoIssuerChainName(version);
+    const pcsHeaderName = appUtil.getTcbInfoIssuerChainName(global.PCS_VERSION);
     result[issuerChainName] = pcsClient.getHeaderValue(
         pck_server_res.headers,
-        issuerChainName
+        pcsHeaderName
     );
 
     await sequelize.transaction(async() => {

--- a/service/services/refreshService.js
+++ b/service/services/refreshService.js
@@ -288,7 +288,7 @@ async function refreshOneTcb(fmspc, type, version, updateType) {
         await pcsCertificatesDao.upsertTcbInfoIssuerChain(
             pcsClient.getHeaderValue(
                 pckServerRes.headers,
-                appUtil.getTcbInfoIssuerChainName(version)
+                appUtil.getTcbInfoIssuerChainName(global.PCS_VERSION)
             )
         );
     } else {


### PR DESCRIPTION
## Summary

Intel retired the v3 PCS API in 2026 — it now returns HTTP 410 Gone. Two blocks in `pcs_client.js` rewrote v4 URLs to v3 when `version === 3`, causing PCCS to receive 410 and return 404 to clients before the v4 path could complete. This broke platform registration via `/platforms`.

## Changes

- Remove both `if (global.PCS_VERSION === 4 && version === 3)` URL downgrade blocks in `getTcb` and `getEnclaveIdentity` (`pcs_client.js`)
- Fix TCB issuer chain header extraction in `getTcbInfoFromPCS` (`commonCacheLogic.js`) and `refreshOneTcb` (`refreshService.js`): the v4 PCS returns header `TCB-Info-Issuer-Chain` while v3 used `SGX-TCB-Info-Issuer-Chain`. The code now reads the header using `global.PCS_VERSION` (matching the actual PCS response) while storing under the client-requested version key. This is a no-op when both sides are v4 and correctly handles v3-to-v4 config upgrades.

## Verification

Confirmed via curl against `api.trustedservices.intel.com`:

| Endpoint | v3 (`/v3/`) | v4 (`/v4/`) |
|----------|-------------|-------------|
| `tcb` | 410 Gone | 200 OK |
| `qe/identity` | 410 Gone | 200 OK |
| `qve/identity` | 410 Gone | 200 OK |

- v4 QE/QVE identity responses are structurally identical to v3 (version 2, same `SGX-Enclave-Identity-Issuer-Chain` header)
- v4 TCB responses use a newer inner structure (tcbInfo version 3 vs v3's version 2) and a different response header (`TCB-Info-Issuer-Chain` vs `SGX-TCB-Info-Issuer-Chain`)

## Test plan

- [x] Verified v3 PCS returns 410, v4 returns 200
- [x] Verified header name differences between v3 and v4 responses
- [x] Deployed and tested platform registration with `PCS_VERSION = 4`
- [ ] Query PCCS v3 API for TCB info — confirm issuer chain header is present
- [ ] Refresh cache after v3→v4 config upgrade — confirm v3 entries updated correctly
